### PR TITLE
Move to using npm oidc trusted publishers (from token)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish to NPM
 on:
   release:
     types: [ created ]
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,5 +24,3 @@ jobs:
         run: npm run build
       - name: Publish package on NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
> [Prefer trusted publishing over tokens](https://docs.npmjs.com/trusted-publishers#prefer-trusted-publishing-over-tokens)
When trusted publishing is available for your workflow, always prefer it over long-lived tokens. Traditional npm tokens pose several security risks:
  They can be accidentally exposed in CI logs or configuration files
  They require manual rotation and management
  If compromised, they provide persistent access until revoked
  They often have broader permissions than necessary
  Trusted publishing eliminates these risks by using short-lived, workflow-specific credentials that are automatically managed and cannot be extracted.

Using trusted publishers is more convenient and circumvents any impacts to changes NPM is rolling out with their publishing tokens.

