### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/require_coverage.yml
+++ b/.github/workflows/require_coverage.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NicolaWealth/rate_limit/security/code-scanning/3](https://github.com/NicolaWealth/rate_limit/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the minimum required scopes. For a workflow that only checks out code and runs local Node.js commands, `contents: read` is sufficient; no write permissions or other scopes (issues, pull-requests, actions, etc.) are needed.

The best fix here is to add a workflow‑level `permissions` block near the top of `.github/workflows/require_coverage.yml`, so it applies to all jobs by default. Insert it after the `name:` (or after the `on:` block; both are valid) and set `contents: read`. This will ensure the `coverage` job that uses `actions/checkout@v3` can read the repository content but cannot perform write operations via `GITHUB_TOKEN`. No changes to the steps, container, or environment variables are required, and no additional libraries or methods are needed.

Concretely: edit `.github/workflows/require_coverage.yml` to add:

```yaml
permissions:
  contents: read
```

at the top level, between existing keys. No other parts of the workflow need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to enhance permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->