### PR TITLE
Set the correct repo URL in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nicolawealth/rate_limit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nicolawealth/rate_limit",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@nicolawealth/code_coverage_extractor": "^2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 
 {
   "name": "@nicolawealth/rate_limit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "source": "src/index.ts",
+
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NicolaWealth/rate_limit.git"
+  },
 
   "main": "./dist/index.umd.js",
   "module": "./dist/index.modern.js",


### PR DESCRIPTION
Npm is now strict about needing this URL.

The error from the failing publish to npm.
> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@nicolawealth%2frate_limit - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/NicolaWealth/rate_limit" from provenance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.0.6
  * Added repository metadata to package configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->